### PR TITLE
Fix install/deploy for extra'd requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Upgrade python tooling
       run: python -m pip install --upgrade pip setuptools wheel
     - name: Install dependencies
-      run: python -m pip install -r requirements.txt --no-deps
+      run: python -m pip install -r requirements.txt
     - name: Install test dependencies
       run: python -m pip install pytest pretend
     - name: Test

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,12 @@ exceptiongroup==1.0.0rc2 \
     --hash=sha256:4d254b05231bed1d43079bdcfe0f1d66c0ab4783e6777a329355f9b78de3ad83 \
     --hash=sha256:83e465152bd0bc2bc40d9b75686854260f86946bb947c652b5cafc31cdff70e7
     # via cattrs
+# This requirement duplicates the line below, without an extra. We need this to
+# work around https://github.com/pypa/pip/issues/9644 because we can't use
+# --no-deps when this gets installed by GCF
+google-api-core==2.7.1 \
+    --hash=sha256:6be1fc59e2a7ba9f66808bbc22f976f81e4c3e7ab20fa0620ce42686288787d0 \
+    --hash=sha256:b0fa577e512f0c8e063386b974718b8614586a798c5894ed34bedf256d9dae24
 google-api-core[grpc]==2.7.1 \
     --hash=sha256:6be1fc59e2a7ba9f66808bbc22f976f81e4c3e7ab20fa0620ce42686288787d0 \
     --hash=sha256:b0fa577e512f0c8e063386b974718b8614586a798c5894ed34bedf256d9dae24
@@ -121,6 +127,12 @@ google-resumable-media==2.3.2 \
     # via
     #   google-cloud-bigquery
     #   google-cloud-storage
+# This requirement duplicates the line below, without an extra. We need this to
+# work around https://github.com/pypa/pip/issues/9644 because we can't use
+# --no-deps when this gets installed by GCF
+googleapis-common-protos==1.56.0 \
+    --hash=sha256:4007500795bcfc269d279f0f7d253ae18d6dc1ff5d5a73613ffe452038b1ec5f \
+    --hash=sha256:60220c89b8bd5272159bed4929ecdc1243ae1f73437883a499a44a1cbc084086
 googleapis-common-protos[grpc]==1.56.0 \
     --hash=sha256:4007500795bcfc269d279f0f7d253ae18d6dc1ff5d5a73613ffe452038b1ec5f \
     --hash=sha256:60220c89b8bd5272159bed4929ecdc1243ae1f73437883a499a44a1cbc084086


### PR DESCRIPTION
The fix in #99 won't work for deploy because we don't have any control over the `pip install` invocation used.

Instead, we can work around this by duplicating the requirement in the requirements file. This will likely get removed by Dependabot when `pip-compile` is run, and we'll need to manually add it back until https://github.com/pypa/pip/issues/9644 is fixed. 🙁 