### PR TITLE
Add uv parser

### DIFF
--- a/linehaul/ua/parser.py
+++ b/linehaul/ua/parser.py
@@ -197,6 +197,26 @@ def TwineUserAgent(*, version, impl_name, impl_version):
     }
 
 
+@_parser.register
+@ua_parser
+def UvUserAgent(user_agent):
+    # We're only concerned about uv user agents.
+    if not user_agent.startswith("uv/"):
+        raise UnableToParse
+
+    # This format was brand new in uv 0.1.22, so we'll need to restrict it
+    # to only versions of uv newer than that.
+    version_str = user_agent.split()[0].split("/", 1)[1]
+    version = packaging.version.parse(version_str)
+    if version not in SpecifierSet(">=0.1.22", prereleases=True):
+        raise UnableToParse
+
+    try:
+        return json.loads(user_agent.split(maxsplit=1)[1])
+    except (json.JSONDecodeError, UnicodeDecodeError, IndexError):
+        raise UnableToParse from None
+
+
 # TODO: We should probably consider not parsing this specially, and moving it to
 #       just the same as we treat browsers, since we don't really know anything
 #       about it-- including whether or not the version of Python mentioned is

--- a/tests/unit/ua/fixtures/uv.yml
+++ b/tests/unit/ua/fixtures/uv.yml
@@ -1,0 +1,58 @@
+# uv >=0.1.22 format
+
+# OSX Example
+- ua: 'uv/0.1.22 {"installer":{"name":"uv","version":"0.1.22"},"python":"3.12.2","implementation":{"name":"CPython","version":"3.12.2"},"distro":{"name":"macOS","version":"14.4","id":null,"libc":null},"system":{"name":"Darwin","release":"23.2.0"},"cpu":"arm64","openssl_version":null,"setuptools_version":null,"rustc_version":null,"ci":null}'
+  result:
+    installer:
+      name: uv
+      version: '0.1.22'
+    python: 3.12.2
+    implementation:
+      name: CPython
+      version: 3.12.2
+    distro:
+      name: macOS
+      version: 14.4
+    system:
+      name: Darwin
+      release: 23.2.0
+    cpu: arm64
+
+# Linux (Ubuntu) Example
+- ua: 'uv/0.1.22 {"installer":{"name":"uv","version":"0.1.22"},"python":"3.12.2","implementation":{"name":"CPython","version":"3.12.2"},"distro":{"name":"Ubuntu","version":"22.04","id":"jammy","libc":{"lib":"glibc","version":"2.35"}},"system":{"name":"Linux","release":"6.5.0-1016-azure"},"cpu":"x86_64","openssl_version":null,"setuptools_version":null,"rustc_version":null,"ci":true}'
+  result:
+    installer:
+      name: uv
+      version: '0.1.22'
+    python: 3.12.2
+    implementation:
+      name: CPython
+      version: 3.12.2
+    distro:
+      name: Ubuntu
+      version: 22.04
+      id: jammy
+      libc:
+        lib: glibc
+        version: 2.35
+    system:
+      name: Linux
+      release: 6.5.0-1016-azure
+    cpu: x86_64
+    ci: true
+
+# Windows Example
+- ua: 'uv/0.1.22 {"installer":{"name":"uv","version":"0.1.22"},"python":"3.12.2","implementation":{"name":"CPython","version":"3.12.2"},"distro":null,"system":{"name":"Windows","release":"2022Server"},"cpu":"AMD64","openssl_version":null,"setuptools_version":null,"rustc_version":null,"ci":true}'
+  result:
+    installer:
+      name: uv
+      version: '0.1.22'
+    python: 3.12.2
+    implementation:
+      name: CPython
+      version: 3.12.2
+    system:
+      name: Windows
+      release: 2022Server
+    cpu: AMD64
+    ci: true

--- a/tests/unit/ua/test_parser.py
+++ b/tests/unit/ua/test_parser.py
@@ -160,6 +160,22 @@ class TestPip1_4UserAgent:
         assert parser.Pip1_4UserAgent(ua) == expected
 
 
+class TestUvUserAgent:
+    @given(st.text().filter(lambda i: not i.startswith("uv/")))
+    def test_not_uv(self, ua):
+        with pytest.raises(parser.UnableToParse):
+            parser.UvUserAgent(ua)
+
+    @given(st_version(max_version="0.1.21"))
+    def test_invalid_version(self, version):
+        with pytest.raises(parser.UnableToParse):
+            parser.UvUserAgent(f"""uv/{version} {{"installer":{{"name":"uv","version":"{version}"}}}}""")
+
+    @given(st.text(max_size=100).filter(lambda i: not _is_valid_json(i)))
+    def test_invalid_json(self, json_blob):
+        with pytest.raises(parser.UnableToParse):
+            parser.UvUserAgent(f"uv/0.1.22 {json_blob}")
+
 class TestParse:
     @given(st.text())
     def test_unknown_user_agent(self, user_agent):


### PR DESCRIPTION
Hi 👋 

[uv](https://github.com/astral-sh/uv) recently added support to `linehaul` in astral-sh/uv#2493 to match what pip does as part of astral-sh/uv#1958 .

This PR aims to add support to `uv` user agents starting with release `0.1.22`.

The implementation here in nature matches what pip does, including adding tests and fixtures for uv.

Closes astral-sh/uv#2568