### PR TITLE
Upgrade to gen2 cloud functions

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,7 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   args: [
     'functions', 'deploy', 'linehaul-ingestor',
+    '--gen2',
     '--trigger-resource', 'linehaul-logs',
     '--trigger-event', 'google.storage.object.finalize',
     '--runtime', 'python311',
@@ -13,6 +14,7 @@ steps:
 - name: 'gcr.io/cloud-builders/gcloud'
   args: [
     'functions', 'deploy', 'linehaul-publisher',
+    '--gen2',
     '--trigger-topic', 'linehaul-publisher-topic',
     '--runtime', 'python311',
     '--source', '.',


### PR DESCRIPTION
https://cloud.google.com/functions/docs/concepts/version-comparison

This will allow us to enable Sentry, which is only available in the new runtime.