### PR TITLE
Update region to us-central1

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@ steps:
   args: [
     'functions', 'deploy', 'linehaul-ingestor',
     '--gen2',
-    '--region', 'us-east5',
+    '--region', 'us-central1',
     '--trigger-resource', 'linehaul-logs',
     '--trigger-event', 'google.storage.object.finalize',
     '--runtime', 'python311',
@@ -16,7 +16,7 @@ steps:
   args: [
     'functions', 'deploy', 'linehaul-publisher',
     '--gen2',
-    '--region', 'us-east5',
+    '--region', 'us-central1',
     '--trigger-topic', 'linehaul-publisher-topic',
     '--runtime', 'python311',
     '--source', '.',


### PR DESCRIPTION
`Step #0: ERROR: (gcloud.functions.deploy) ResponseError: status=[400], code=[Ok], message=[Validation failed for trigger projects/the-psf/locations/us-east5/triggers/linehaul-ingestor-955167: Bucket 'linehaul-logs' is in location 'us-central1', but the trigger location is 'us-east5'. The trigger must be in the same location as the bucket. Try redeploying and changing the trigger location to 'us-central1'`