### PR TITLE
Handle malformed gzip log objects without retrying indefinitely

### DIFF
--- a/linehaul/events/parser.py
+++ b/linehaul/events/parser.py
@@ -201,7 +201,7 @@ def _value_or_none(value):
 
 def parse(message):
     try:
-        parsed = MESSAGE.parse_string(message, parseAll=True)
+        parsed = MESSAGE.parse_string(message, parse_all=True)
     except ParseException as exc:
         raise UnparseableEvent("{!r} {}".format(message, exc)) from None
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import datetime
 import os
 import json
 import gzip
+import zlib
 import shlex
 
 from tempfile import NamedTemporaryFile
@@ -86,30 +87,41 @@ def process_fastly_log(data, context):
         download_results_file = stack.enter_context(NamedTemporaryFile())
 
         min_timestamp = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
-        for line in input_file:
-            try:
-                res = parse(line.decode())
-                min_timestamp = min(min_timestamp, res.timestamp)
-                if res is not None:
-                    if res.__class__.__name__ == Simple.__name__:
-                        simple_results_file.write(
-                            json.dumps(_cattr.unstructure(res)).encode() + b"\n"
-                        )
-                        simple_lines += 1
-                    elif res.__class__.__name__ == Download.__name__:
-                        download_results_file.write(
-                            json.dumps(_cattr.unstructure(res)).encode() + b"\n"
-                        )
-                        download_lines += 1
+        try:
+            for line in input_file:
+                try:
+                    res = parse(line.decode())
+                    min_timestamp = min(min_timestamp, res.timestamp)
+                    if res is not None:
+                        if res.__class__.__name__ == Simple.__name__:
+                            simple_results_file.write(
+                                json.dumps(_cattr.unstructure(res)).encode() + b"\n"
+                            )
+                            simple_lines += 1
+                        elif res.__class__.__name__ == Download.__name__:
+                            download_results_file.write(
+                                json.dumps(_cattr.unstructure(res)).encode() + b"\n"
+                            )
+                            download_lines += 1
+                        else:
+                            unprocessed_file.write(line)
+                            unprocessed_lines += 1
                     else:
                         unprocessed_file.write(line)
                         unprocessed_lines += 1
-                else:
+                except Exception:
                     unprocessed_file.write(line)
                     unprocessed_lines += 1
-            except Exception:
-                unprocessed_file.write(line)
-                unprocessed_lines += 1
+        except (gzip.BadGzipFile, EOFError, zlib.error) as exc:
+            print(
+                f"Skipping malformed gzip gs://{data['bucket']}/{data['name']}: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            try:
+                bob_logs_log_blob.delete()
+            except exceptions.NotFound:
+                pass
+            return
 
         total = unprocessed_lines + simple_lines + download_lines
         print(

--- a/test_functions.py
+++ b/test_functions.py
@@ -102,6 +102,43 @@ def test_process_fastly_log(
     assert blobs[expected_unprocessed_filename].data == expected_unprocessed
 
 
+def test_process_fastly_log_deletes_malformed_gzip(monkeypatch):
+    monkeypatch.setenv("GCP_PROJECT", GCP_PROJECT)
+    monkeypatch.setenv("RESULT_BUCKET", RESULT_BUCKET)
+
+    reload(main)
+
+    def _download_to_file(file_handler):
+        file_handler.write(b"not gzip data")
+
+    get_blob_stub = pretend.stub(
+        download_to_file=_download_to_file,
+        delete=pretend.call_recorder(lambda: None),
+    )
+
+    bucket_stub = pretend.stub(
+        get_blob=pretend.call_recorder(lambda a: get_blob_stub),
+    )
+    storage_client_stub = pretend.stub(
+        bucket=pretend.call_recorder(lambda a: bucket_stub),
+    )
+    monkeypatch.setattr(
+        main, "storage", pretend.stub(Client=lambda: storage_client_stub)
+    )
+
+    data = {
+        "name": "poison.log.gz",
+        "bucket": "my-bucket",
+    }
+    context = pretend.stub()
+
+    main.process_fastly_log(data, context)
+
+    assert storage_client_stub.bucket.calls == [pretend.call("my-bucket")]
+    assert bucket_stub.get_blob.calls == [pretend.call("poison.log.gz")]
+    assert get_blob_stub.delete.calls == [pretend.call()]
+
+
 GCP_PROJECT = "my-gcp-project"
 BIGQUERY_DATASET = "my-bigquery-dataset"
 BIGQUERY_SIMPLE_TABLE = "my-simple-table"


### PR DESCRIPTION
Currently, if the gzip log file to process is malformed, there will be an uncaught exception while advancing the file iterator. Since the function is deployed with `--retry`,  it will be retried [for up to 7 days](https://cloud.google.com/functions/docs/reference/rest/v1/projects.locations.functions#Retry).
> A failed execution will be retried up to 7 days with an exponential backoff (capped at 10 seconds).

This PR wraps that in a `try` block, deleting the file if there is an compression/EOF error while iterating over it (this is one solution, another might be moving the file to a separate bucket for debugging/diagnosis)

It also fixes a deprecation error from `pyparsing`'s [parse_string](https://pyparsing-docs.readthedocs.io/en/latest/pyparsing.html#pyparsing.ParserElement.parse_file)

cc @miketheman 